### PR TITLE
Add postinstall for installing via Github

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "cover": "babel-node ./node_modules/.bin/babel-istanbul cover test/index.js | tap-spec",
     "lint": "eslint src test",
     "prepublish": "npm run lint && npm test && npm run clean && npm run build",
-    "test": "babel-node test/index.js | tap-spec"
+    "test": "babel-node test/index.js | tap-spec",
+    "postinstall": "npm run build"
   },
   "repository": "agraboso/redux-api-middleware",
   "homepage": "https://github.com/agraboso/redux-api-middleware",


### PR DESCRIPTION
This makes it possible to install from Github (temporary solution until package maintainer is back).